### PR TITLE
Adding foldLoading extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.1.2] - TBD
 - Added LC type.
+- Adding `foldLoading` extension method to `LCE`, `UCE` and `UCT` types. 
 
 ## [0.1.1] - January 5, 2021
 - Added UCE type.

--- a/lce/src/main/java/com/laimiux/lce/FoldLoading.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldLoading.kt
@@ -1,0 +1,31 @@
+package com.laimiux.lce
+
+inline fun <L, C, E, T> LCE<L, C, E>.foldLoading(
+    crossinline onLoading: (L) -> T,
+    crossinline onOther: (CE<C, E>) -> T
+): T {
+    return foldTypes(
+        onLoading = { onLoading(it.value) },
+        onOther = onOther
+    )
+}
+
+inline fun <C, E, T> UCE<C, E>.foldLoading(
+    crossinline onLoading: () -> T,
+    crossinline onOther: (CE<C, E>) -> T
+): T {
+    return foldTypes(
+        onLoading = { onLoading() },
+        onOther = onOther
+    )
+}
+
+inline fun <C, T> UCT<C>.foldLoading(
+    crossinline onLoading: () -> T,
+    crossinline onOther: (CT<C>) -> T
+): T {
+    return foldTypes(
+        onLoading = { onLoading() },
+        onOther = onOther
+    )
+}

--- a/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
@@ -12,6 +12,30 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
     }
 }
 
+@JvmName("foldLoadingType")
+inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
+    crossinline onLoading: (Type.Loading<L>) -> T,
+    crossinline onOther: (CE<C, E>) -> T
+): T {
+    return foldTypes(
+        onLoading = onLoading,
+        onContent = onOther,
+        onError = onOther
+    )
+}
+
+@JvmName("foldErrorType")
+inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
+    crossinline onError: (Type.Error<E>) -> T,
+    crossinline onOther: (LC<L, C>) -> T
+): T {
+    return foldTypes(
+        onLoading = onOther,
+        onContent = onOther,
+        onError = onError
+    )
+}
+
 inline fun <C, E, T> UCE<C, E>.foldTypes(
     crossinline onLoading: (Type.Loading.UnitType) -> T,
     crossinline onContent: (Type.Content<C>) -> T,
@@ -25,6 +49,30 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
     }
 }
 
+@JvmName("foldLoadingType")
+inline fun <C, E, T> UCE<C, E>.foldTypes(
+    crossinline onLoading: (Type.Loading.UnitType) -> T,
+    crossinline onOther: (CE<C, E>) -> T
+): T {
+    return foldTypes(
+        onLoading = onLoading,
+        onContent = onOther,
+        onError = onOther
+    )
+}
+
+@JvmName("foldErrorType")
+inline fun <C, E, T> UCE<C, E>.foldTypes(
+    crossinline onError: (Type.Error<E>) -> T,
+    crossinline onOther: (UC<C>) -> T
+): T {
+    return foldTypes(
+        onLoading = onOther,
+        onContent = onOther,
+        onError = onError
+    )
+}
+
 inline fun <C, T> UCT<C>.foldTypes(
     crossinline onLoading: (Type.Loading.UnitType) -> T,
     crossinline onContent: (Type.Content<C>) -> T,
@@ -36,6 +84,30 @@ inline fun <C, T> UCT<C>.foldTypes(
         is Type.Error.ThrowableType -> onError(type)
         else -> throw IllegalStateException("this should not happen: $type")
     }
+}
+
+@JvmName("foldLoadingType")
+inline fun <C, T> UCT<C>.foldTypes(
+    crossinline onLoading: (Type.Loading.UnitType) -> T,
+    crossinline onOther: (CT<C>) -> T
+): T {
+    return foldTypes(
+        onLoading = onLoading,
+        onContent = onOther,
+        onError = onOther
+    )
+}
+
+@JvmName("foldErrorType")
+inline fun <C, T> UCT<C>.foldTypes(
+    crossinline onError: (Type.Error.ThrowableType) -> T,
+    crossinline onOther: (UC<C>) -> T
+): T {
+    return foldTypes(
+        onLoading = onOther,
+        onContent = onOther,
+        onError = onError
+    )
 }
 
 inline fun <C, E, T> CE<C, E>.foldTypes(

--- a/lce/src/test/java/com/laimiux/lce/FoldLoadingTest.kt
+++ b/lce/src/test/java/com/laimiux/lce/FoldLoadingTest.kt
@@ -1,0 +1,37 @@
+package com.laimiux.lce
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FoldLoadingTest {
+
+    @Test
+    fun `LCE loading foldLoading to content`() {
+        val result = LCE.loading().foldLoading(
+            onLoading = { CE.content(0) },
+            onOther = { it }
+        )
+
+        assertThat(result).isEqualTo(CE.content(0))
+    }
+
+    @Test
+    fun `UCE loading foldLoading to content`() {
+        val result = UCE.loading().foldLoading(
+            onLoading = { CE.content(0) },
+            onOther = { it }
+        )
+
+        assertThat(result).isEqualTo(CE.content(0))
+    }
+
+    @Test
+    fun `UCT loading foldLoading to content`() {
+        val result = UCT.loading().foldLoading(
+            onLoading = { CT.content(0) },
+            onOther = { it }
+        )
+
+        assertThat(result).isEqualTo(CT.content(0))
+    }
+}


### PR DESCRIPTION
## What
Adding a specialized `foldLoading` extension to `LCE`, `UCE` and `UCT` types. This allows us to separate loading from the other two cases (content / error).

For example, we can use `foldLoading` to replace loading state with a content state.
```kotlin
val loadingEvent: UCT<Result> = ...
val event: CT<Result> = loadingEvent.foldLoading(
  onLoading = { CT.content(cachedResult) },
  onOther = { it }
) 
```