### PR TITLE
Adding extra asCE, asCT, asLC, asUC extensions.

### DIFF
--- a/lce/src/test/java/com/laimiux/lce/ConvertTest.kt
+++ b/lce/src/test/java/com/laimiux/lce/ConvertTest.kt
@@ -2,7 +2,6 @@ package com.laimiux.lce
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import java.lang.RuntimeException
 
 class ConvertTest {
 
@@ -20,6 +19,11 @@ class ConvertTest {
     @Test fun `LCE as CE returns error when error`() {
         val result = LCE.error("").asCE()
         assertThat(result).isEqualTo(CE.error(""))
+    }
+
+    @Test fun `LCE as CE where we map loading to content`() {
+        val result = LCE.loading().asCE { CE.content(0) }
+        assertThat(result).isEqualTo(CE.content(0))
     }
 
     @Test fun `LCE as CT returns null when loading`() {


### PR DESCRIPTION
## What
Extra conversion extensions that take a function that maps the dropped state into other states.

```kotlin
val loadingEvent = LCE.loading()

// We convert LCE to CT where loading event becomes a CT.content() event
val event = loadingEvent.asCT { CT.content(0) }
```