### PR TITLE
Use generic error constructors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `doOnContent` extension to `Observable<CE>` type.
 - Added `flatten` extension method to `LC` and `UC` types.
 - Added `asUCT()` extension to `UCE<C, Throwable>` type.
+- Remove `LCE.error(throwable)`, `UCE.error(throwable)` and `CE.error(throwable)`
 
 ## [0.2.0] - January 11, 2021 
 - Added LC type.

--- a/lce/src/main/java/com/laimiux/lce/CE.kt
+++ b/lce/src/main/java/com/laimiux/lce/CE.kt
@@ -8,7 +8,6 @@ interface CE<out C, out E> {
     companion object {
         fun <T> content(content: T): CE<T, Nothing> = Type.Content(content)
 
-        fun error(error: Throwable): CE<Nothing, Throwable> = Type.Error(error)
         fun <T> error(error: T): CE<Nothing, T> = Type.Error(error)
 
         /**

--- a/lce/src/main/java/com/laimiux/lce/LCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/LCE.kt
@@ -12,7 +12,6 @@ interface LCE<out L, out C, out E> {
 
         fun <T> content(content: T): LCE<Nothing, T, Nothing> = Type.Content(content)
 
-        fun error(error: Throwable): LCE<Nothing, Nothing, Throwable> = Type.Error(error)
         fun <T> error(error: T): LCE<Nothing, Nothing, T> = Type.Error(error)
 
         /**

--- a/lce/src/main/java/com/laimiux/lce/UCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/UCE.kt
@@ -8,7 +8,6 @@ interface UCE<out C, out E> {
     companion object {
         fun loading(): UCE<Nothing, Nothing> = Type.Loading()
         fun <T> content(value: T): UCE<T, Nothing> = Type.Content(value)
-        fun error(error: Throwable): UCE<Nothing, Throwable> = Type.Error.ThrowableType(error)
         fun <T> error(error: T): UCE<Nothing, T> = Type.Error(error)
 
         /**


### PR DESCRIPTION
## What
Remove non-generic `error()` methods from `LCE` / `UCE` / `CE` types.
