### PR TITLE
Remove `crossinline` declarations where possible

### DIFF
--- a/lce/src/main/java/com/laimiux/lce/CE.kt
+++ b/lce/src/main/java/com/laimiux/lce/CE.kt
@@ -15,7 +15,7 @@ interface CE<out C, out E> {
          */
         inline fun <C : Any, E> fromNullable(
             content: C?,
-            crossinline onNull: () -> CE<C, E>
+            onNull: () -> CE<C, E>
         ): CE<C, E> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/CT.kt
+++ b/lce/src/main/java/com/laimiux/lce/CT.kt
@@ -14,7 +14,7 @@ interface CT<out C> {
          */
         inline fun <L, C : Any, E> fromNullable(
             content: C?,
-            crossinline onNull: () -> CT<C>
+            onNull: () -> CT<C>
         ): CT<C> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/ContentOrElse.kt
+++ b/lce/src/main/java/com/laimiux/lce/ContentOrElse.kt
@@ -1,48 +1,48 @@
 package com.laimiux.lce
 
-inline fun <L, C, E> LCE<L, C, E>.contentOrElse(crossinline onOther: (LE<L, E>) -> C): C {
+inline fun <L, C, E> LCE<L, C, E>.contentOrElse(onOther: (LE<L, E>) -> C): C {
     return foldContent(
         onContent = { it },
         onOther = onOther
     )
 }
 
-inline fun <C, E> UCE<C, E>.contentOrElse(crossinline onOther: (UE<E>) -> C): C {
+inline fun <C, E> UCE<C, E>.contentOrElse(onOther: (UE<E>) -> C): C {
     return foldContent(
         onContent = { it },
         onOther = onOther
     )
 }
 
-inline fun <C> UCT<C>.contentOrElse(crossinline onOther: (UT) -> C): C {
+inline fun <C> UCT<C>.contentOrElse(onOther: (UT) -> C): C {
     return foldContent(
         onContent = { it },
         onOther = onOther
     )
 }
 
-inline fun <C, E> CE<C, E>.contentOrElse(crossinline onOther: () -> C): C {
+inline fun <C, E> CE<C, E>.contentOrElse(onOther: () -> C): C {
     return fold(
         onContent = { it },
         onError = { onOther() }
     )
 }
 
-inline fun <C> CT<C>.contentOrElse(crossinline onOther: () -> C): C {
+inline fun <C> CT<C>.contentOrElse(onOther: () -> C): C {
     return fold(
         onContent = { it },
         onError = { onOther() }
     )
 }
 
-inline fun <L, C> LC<L, C>.contentOrElse(crossinline onOther: () -> C): C {
+inline fun <L, C> LC<L, C>.contentOrElse(onOther: () -> C): C {
     return fold(
         onContent = { it },
         onLoading = { onOther() }
     )
 }
 
-inline fun <C> UC<C>.contentOrElse(crossinline onOther: () -> C): C {
+inline fun <C> UC<C>.contentOrElse(onOther: () -> C): C {
     return fold(
         onContent = { it },
         onLoading = { onOther() }

--- a/lce/src/main/java/com/laimiux/lce/Convert.kt
+++ b/lce/src/main/java/com/laimiux/lce/Convert.kt
@@ -38,7 +38,7 @@ fun <C, E> LCE<Any?, C, E>.asCE(): CE<C, E>? {
  * Converts [LCE] to a [CE] by [mapping][map] the loading state to [CE].
  */
 inline fun <L, C, E> LCE<L, C, E>.asCE(
-    crossinline map: (L) -> CE<C, E>
+    map: (L) -> CE<C, E>
 ): CE<C, E> {
     return foldTypes(
         onLoading = { map(it.value) },
@@ -60,7 +60,7 @@ fun <C> LCE<Any?, C, Throwable>.asCT(): CT<C>? {
  * Converts [LCE] to a [CT] by [mapping][map] the loading state to [CT].
  */
 inline fun <L, C> LCE<L, C, Throwable>.asCT(
-    crossinline map: (L) -> CT<C>
+    map: (L) -> CT<C>
 ): CT<C> {
     return foldTypes(
         onLoading = { map(it.value) },
@@ -82,7 +82,7 @@ fun <L, C> LCE<L, C, Any?>.asLC(): LC<L, C>? {
  * Converts [LCE] to a [LC] by [mapping][map] the error state to [LC].
  */
 inline fun <L, C, E> LCE<L, C, E>.asLC(
-    crossinline fold: (E) -> LC<L, C>
+    fold: (E) -> LC<L, C>
 ): LC<L, C> {
     return foldError(
         onError = fold,
@@ -104,7 +104,7 @@ fun <C> LCE<Unit, C, Any?>.asUC(): UC<C>? {
  * Converts [LCE] to a [UC] by [mapping][map] the error state to [UC].
  */
 inline fun <C, E> LCE<Unit, C, E>.asUC(
-    crossinline fold: (E) -> UC<C>
+    fold: (E) -> UC<C>
 ): UC<C> {
     return foldError(
         onError = fold,
@@ -146,7 +146,7 @@ fun <C, E> UCE<C, E>.asCE(): CE<C, E>? {
  * Converts [UCE] to a [CE] by [mapping][map] the loading state to [CE].
  */
 inline fun <C, E> UCE<C, E>.asCE(
-    crossinline map: () -> CE<C, E>
+    map: () -> CE<C, E>
 ): CE<C, E> {
     return asLCE().asCE { map() }
 }
@@ -162,7 +162,7 @@ fun <C> UCE<C, Throwable>.asCT(): CT<C>? {
  * Converts [UCE] to a [CT] by [mapping][map] the loading state to [CT].
  */
 inline fun <C> UCE<C, Throwable>.asCT(
-    crossinline map: () -> CT<C>
+    map: () -> CT<C>
 ): CT<C> {
     return asLCE().asCT { map() }
 }
@@ -182,7 +182,7 @@ fun <C, E> UCE<C, E>.asLC(): LC<Unit, C>? {
  * Converts [UCE] to a [LC] by [mapping][map] the error state to [LC].
  */
 inline fun <C, E> UCE<C, E>.asLC(
-    crossinline fold: (E) -> LC<Unit, C>
+    fold: (E) -> LC<Unit, C>
 ): LC<Unit, C> {
     return asLCE().asLC(fold)
 }
@@ -202,7 +202,7 @@ fun <C, E> UCE<C, E>.asUC(): UC<C>? {
  * Converts [UCE] to a [UC] by [mapping][map] the error state to [UC].
  */
 inline fun <C, E> UCE<C, E>.asUC(
-    crossinline fold: (E) -> UC<C>
+    fold: (E) -> UC<C>
 ): UC<C> {
     return asLCE().asUC(fold)
 }
@@ -244,7 +244,7 @@ fun <C> UCT<C>.asCT(): CT<C>? {
  * Converts [UCT] to a [CT] by [mapping][map] the loading state to [CT].
  */
 inline fun <C> UCT<C>.asCT(
-    crossinline map: () -> CT<C>
+    map: () -> CT<C>
 ): CT<C> {
     return asLCE().asCT { map() }
 }
@@ -276,7 +276,7 @@ fun <C, E> UCT<C>.asUCE(map: (throwable: Throwable) -> E): UCE<C, E> {
  * Converts [UCT] to a [CE] by [mapping][map] the loading state to [CE].
  */
 inline fun <C> UCT<C>.asCE(
-    crossinline map: () -> CE<C, Throwable>
+    map: () -> CE<C, Throwable>
 ): CE<C, Throwable> {
     return asLCE().asCE { map() }
 }
@@ -293,7 +293,7 @@ fun <C> UCT<C>.asLC(): LC<Unit, C>? {
  * Converts [UCT] to a [LC] by [mapping][map] the error state to [LC].
  */
 inline fun <C> UCT<C>.asLC(
-    crossinline fold: (Throwable) -> LC<Unit, C>
+    fold: (Throwable) -> LC<Unit, C>
 ): LC<Unit, C> {
     return asLCE().asLC(fold)
 }
@@ -302,7 +302,7 @@ inline fun <C> UCT<C>.asLC(
  * Returns null on error, otherwise returns [UC].
  */
 inline fun <C> UCT<C>.asUC(
-    crossinline fold: (Throwable) -> UC<C>
+    fold: (Throwable) -> UC<C>
 ): UC<C> {
     return asLCE().asUC(fold)
 }
@@ -318,7 +318,7 @@ fun <C> UCT<C>.asUC(): UC<C>? {
  * Converts [UCT] to a [UC] by [mapping][map] the error state to [UC].
  */
 inline fun <C> UCT<C>.asLC(
-    crossinline fold: (Throwable) -> UC<C>
+    fold: (Throwable) -> UC<C>
 ): UC<C> {
     return asLCE().asUC(fold)
 }

--- a/lce/src/main/java/com/laimiux/lce/FlatMapContent.kt
+++ b/lce/src/main/java/com/laimiux/lce/FlatMapContent.kt
@@ -14,7 +14,7 @@ package com.laimiux.lce
  * ```
  */
 inline fun <L, C, E, NewC> LCE<L, C, E>.flatMapContent(
-    crossinline transform: (C) -> LCE<L, NewC, E>
+    transform: (C) -> LCE<L, NewC, E>
 ): LCE<L, NewC, E> {
     return foldTypes(
         onLoading = { it },
@@ -24,7 +24,7 @@ inline fun <L, C, E, NewC> LCE<L, C, E>.flatMapContent(
 }
 
 inline fun <C, E, NewC> UCE<C, E>.flatMapContent(
-    crossinline transform: (C) -> UCE<NewC, E>
+    transform: (C) -> UCE<NewC, E>
 ): UCE<NewC, E> {
     return foldTypes(
         onLoading = { it },
@@ -34,7 +34,7 @@ inline fun <C, E, NewC> UCE<C, E>.flatMapContent(
 }
 
 inline fun <C, NewC> UCT<C>.flatMapContent(
-   crossinline transform: (C) -> UCT<NewC>
+   transform: (C) -> UCT<NewC>
 ): UCT<NewC> {
     return foldTypes(
         onLoading = { it },
@@ -44,7 +44,7 @@ inline fun <C, NewC> UCT<C>.flatMapContent(
 }
 
 inline fun <C, E, NewC> CE<C, E>.flatMapContent(
-    crossinline transform: (C) -> CE<NewC, E>
+    transform: (C) -> CE<NewC, E>
 ): CE<NewC, E> {
     return foldTypes(
         onContent = { transform(it.value) },
@@ -53,7 +53,7 @@ inline fun <C, E, NewC> CE<C, E>.flatMapContent(
 }
 
 inline fun <C, NewC> CT<C>.flatMapContent(
-    crossinline transform: (C) -> CT<NewC>
+    transform: (C) -> CT<NewC>
 ): CT<NewC> {
     return foldTypes(
         onContent = { transform(it.value) },
@@ -62,7 +62,7 @@ inline fun <C, NewC> CT<C>.flatMapContent(
 }
 
 inline fun <L, C, NewC> LC<L, C>.flatMapContent(
-    crossinline transform: (C) -> LC<L, NewC>
+    transform: (C) -> LC<L, NewC>
 ): LC<L, NewC> {
     return foldTypes(
         onLoading = { it },
@@ -71,7 +71,7 @@ inline fun <L, C, NewC> LC<L, C>.flatMapContent(
 }
 
 inline fun <C, NewC> UC<C>.flatMapContent(
-    crossinline transform: (C) -> UC<NewC>
+    transform: (C) -> UC<NewC>
 ): UC<NewC> {
     return foldTypes(
         onLoading = { it },

--- a/lce/src/main/java/com/laimiux/lce/FlatMapError.kt
+++ b/lce/src/main/java/com/laimiux/lce/FlatMapError.kt
@@ -1,7 +1,7 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, NewE> LCE<L, C, E>.flatMapError(
-    crossinline map: (E) -> LCE<L, C, NewE>
+    map: (E) -> LCE<L, C, NewE>
 ): LCE<L, C, NewE> {
     return foldTypes(
         onError = { map(it.value) },
@@ -11,7 +11,7 @@ inline fun <L, C, E, NewE> LCE<L, C, E>.flatMapError(
 }
 
 inline fun <C, E, NewE> UCE<C, E>.flatMapError(
-    crossinline map: (E) -> UCE<C, NewE>
+    map: (E) -> UCE<C, NewE>
 ): UCE<C, NewE> {
     return foldTypes(
         onError = { map(it.value) },
@@ -21,7 +21,7 @@ inline fun <C, E, NewE> UCE<C, E>.flatMapError(
 }
 
 inline fun <C> UCT<C>.flatMapError(
-    crossinline map: (Throwable) -> UCT<C>
+    map: (Throwable) -> UCT<C>
 ): UCT<C> {
     return foldTypes(
         onError = { map(it.value) },
@@ -31,7 +31,7 @@ inline fun <C> UCT<C>.flatMapError(
 }
 
 inline fun <C, E, NewE> CE<C, E>.flatMapError(
-    crossinline map: (E) -> CE<C, NewE>
+    map: (E) -> CE<C, NewE>
 ): CE<C, NewE> {
     return foldTypes(
         onError = { map(it.value) },
@@ -40,7 +40,7 @@ inline fun <C, E, NewE> CE<C, E>.flatMapError(
 }
 
 inline fun <C> CT<C>.flatMapError(
-    crossinline map: (Throwable) -> CT<C>
+    map: (Throwable) -> CT<C>
 ): CT<C> {
     return foldTypes(
         onError = { map(it.value) },

--- a/lce/src/main/java/com/laimiux/lce/FlatMapLoading.kt
+++ b/lce/src/main/java/com/laimiux/lce/FlatMapLoading.kt
@@ -1,7 +1,7 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, NewL> LCE<L, C, E>.flatMapLoading(
-    crossinline map: (L) -> LCE<NewL, C, E>
+    map: (L) -> LCE<NewL, C, E>
 ): LCE<NewL, C, E> {
     return foldTypes(
         onLoading = { map(it.value) },
@@ -11,7 +11,7 @@ inline fun <L, C, E, NewL> LCE<L, C, E>.flatMapLoading(
 }
 
 inline fun <C, E> UCE<C, E>.flatMapLoading(
-    crossinline map: () -> UCE<C, E>
+    map: () -> UCE<C, E>
 ): UCE<C, E> {
     return foldTypes(
         onLoading = { map() },
@@ -21,7 +21,7 @@ inline fun <C, E> UCE<C, E>.flatMapLoading(
 }
 
 inline fun <C> UCT<C>.flatMapLoading(
-    crossinline map: () -> UCT<C>
+    map: () -> UCT<C>
 ): UCT<C> {
     return foldTypes(
         onLoading = { map() },
@@ -31,7 +31,7 @@ inline fun <C> UCT<C>.flatMapLoading(
 }
 
 inline fun <L, C, NewL> LC<L, C>.flatMapLoading(
-    crossinline map: () -> LC<NewL, C>
+    map: () -> LC<NewL, C>
 ): LC<NewL, C> {
     return foldTypes(
         onLoading = { map() },
@@ -40,7 +40,7 @@ inline fun <L, C, NewL> LC<L, C>.flatMapLoading(
 }
 
 inline fun <C> UC<C>.flatMapLoading(
-    crossinline map: () -> UC<C>
+    map: () -> UC<C>
 ): UC<C> {
     return foldTypes(
         onLoading = { map() },

--- a/lce/src/main/java/com/laimiux/lce/FlatMerge.kt
+++ b/lce/src/main/java/com/laimiux/lce/FlatMerge.kt
@@ -5,7 +5,7 @@ package com.laimiux.lce
  */
 inline fun <C, C2, E, T> UCE<C, E>.flatMerge(
     other: UCE<C2, E>,
-    crossinline merge: (C, C2) -> UCE<T, E>
+    merge: (C, C2) -> UCE<T, E>
 ): UCE<T, E> {
     return takeFirstError(other) { first, second ->
         first.asUCE().flatMapContent { firstContent ->
@@ -21,7 +21,7 @@ inline fun <C, C2, E, T> UCE<C, E>.flatMerge(
  */
 inline fun <C, C2, T> UCT<C>.flatMerge(
     other: UCT<C2>,
-    crossinline merge: (C, C2) -> UCT<T>
+    merge: (C, C2) -> UCT<T>
 ): UCT<T> {
     return takeFirstError(other) { first, second ->
         first.asUCT().flatMapContent { firstContent ->
@@ -37,7 +37,7 @@ inline fun <C, C2, T> UCT<C>.flatMerge(
  */
 inline fun <L, C, C2, T> LC<L, C>.flatMerge(
     other: LC<L, C2>,
-    crossinline merge: (C, C2) -> LC<L, T>
+    merge: (C, C2) -> LC<L, T>
 ): LC<L, T> {
     return flatMapContent { first ->
         other.flatMapContent { second ->
@@ -51,7 +51,7 @@ inline fun <L, C, C2, T> LC<L, C>.flatMerge(
  */
 inline fun <C, C2, T> UC<C>.flatMerge(
     other: UC<C2>,
-    crossinline merge: (C, C2) -> UC<T>,
+    merge: (C, C2) -> UC<T>,
 ): UC<T> {
     return flatMapContent { first ->
         other.flatMapContent { second ->

--- a/lce/src/main/java/com/laimiux/lce/Fold.kt
+++ b/lce/src/main/java/com/laimiux/lce/Fold.kt
@@ -5,9 +5,9 @@ package com.laimiux.lce
  * variant [onLoading], [onError] and [onContent].
  */
 inline fun <L, C, E, T> LCE<L, C, E>.fold(
-    crossinline onLoading: (L) -> T,
-    crossinline onError: (E) -> T,
-    crossinline onContent: (C) -> T
+    onLoading: (L) -> T,
+    onError: (E) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading(it.value) },
@@ -21,9 +21,9 @@ inline fun <L, C, E, T> LCE<L, C, E>.fold(
  * variant [onLoading], [onError] and [onContent].
  */
 inline fun <C, E, T> UCE<C, E>.fold(
-    crossinline onLoading: () -> T,
-    crossinline onError: (E) -> T,
-    crossinline onContent: (C) -> T
+    onLoading: () -> T,
+    onError: (E) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading() },
@@ -37,9 +37,9 @@ inline fun <C, E, T> UCE<C, E>.fold(
  * variant [onLoading], [onError] and [onContent].
  */
 inline fun <C, T> UCT<C>.fold(
-    crossinline onLoading: () -> T,
-    crossinline onError: (Throwable) -> T,
-    crossinline onContent: (C) -> T
+    onLoading: () -> T,
+    onError: (Throwable) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading() },
@@ -53,8 +53,8 @@ inline fun <C, T> UCT<C>.fold(
  * variant [onError] and [onContent].
  */
 inline fun <C, E, T> CE<C, E>.fold(
-    crossinline onError: (E) -> T,
-    crossinline onContent: (C) -> T
+    onError: (E) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onContent = { onContent(it.value) },
@@ -67,8 +67,8 @@ inline fun <C, E, T> CE<C, E>.fold(
  * variant [onError] and [onContent].
  */
 inline fun <C, T> CT<C>.fold(
-    crossinline onError: (Throwable) -> T,
-    crossinline onContent: (C) -> T
+    onError: (Throwable) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onContent = { onContent(it.value) },
@@ -81,8 +81,8 @@ inline fun <C, T> CT<C>.fold(
  * variant [onLoading] and [onContent].
  */
 inline fun <L, C, T> LC<L, C>.fold(
-    crossinline onLoading: (L) -> T,
-    crossinline onContent: (C) -> T
+    onLoading: (L) -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading(it.value) },
@@ -95,8 +95,8 @@ inline fun <L, C, T> LC<L, C>.fold(
  * variant [onLoading] and [onContent].
  */
 inline fun <C, T> UC<C>.fold(
-    crossinline onLoading: () -> T,
-    crossinline onContent: (C) -> T
+    onLoading: () -> T,
+    onContent: (C) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading() },

--- a/lce/src/main/java/com/laimiux/lce/FoldContent.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldContent.kt
@@ -1,8 +1,8 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, T> LCE<L, C, E>.foldContent(
-    crossinline onContent: (C) -> T,
-    crossinline onOther: (LE<L, E>) -> T
+    onContent: (C) -> T,
+    onOther: (LE<L, E>) -> T
 ): T {
     return foldTypes(
         onContent = { onContent(it.value) },
@@ -11,8 +11,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldContent(
 }
 
 inline fun <C, E, T> UCE<C, E>.foldContent(
-    crossinline onContent: (C) -> T,
-    crossinline onOther: (UE<E>) -> T
+    onContent: (C) -> T,
+    onOther: (UE<E>) -> T
 ): T {
     return foldTypes(
         onContent = { onContent(it.value) },
@@ -21,8 +21,8 @@ inline fun <C, E, T> UCE<C, E>.foldContent(
 }
 
 inline fun <C, T> UCT<C>.foldContent(
-    crossinline onContent: (C) -> T,
-    crossinline onOther: (UT) -> T
+    onContent: (C) -> T,
+    onOther: (UT) -> T
 ): T {
     return foldTypes(
         onContent = { onContent(it.value) },

--- a/lce/src/main/java/com/laimiux/lce/FoldError.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldError.kt
@@ -1,8 +1,8 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, T> LCE<L, C, E>.foldError(
-    crossinline onError: (E) -> T,
-    crossinline onOther: (LC<L, C>) -> T
+    onError: (E) -> T,
+    onOther: (LC<L, C>) -> T
 ): T {
     return foldTypes(
         onError = { onError(it.value) },
@@ -11,8 +11,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldError(
 }
 
 inline fun <C, E, T> UCE<C, E>.foldError(
-    crossinline onError: (E) -> T,
-    crossinline onOther: (UC<C>) -> T
+    onError: (E) -> T,
+    onOther: (UC<C>) -> T
 ): T {
     return foldTypes(
         onError = { onError(it.value) },
@@ -21,8 +21,8 @@ inline fun <C, E, T> UCE<C, E>.foldError(
 }
 
 inline fun <C, T> UCT<C>.foldError(
-    crossinline onError: (Throwable) -> T,
-    crossinline onOther: (UC<C>) -> T
+    onError: (Throwable) -> T,
+    onOther: (UC<C>) -> T
 ): T {
     return foldTypes(
         onError = { onError(it.value) },

--- a/lce/src/main/java/com/laimiux/lce/FoldLoading.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldLoading.kt
@@ -1,8 +1,8 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, T> LCE<L, C, E>.foldLoading(
-    crossinline onLoading: (L) -> T,
-    crossinline onOther: (CE<C, E>) -> T
+    onLoading: (L) -> T,
+    onOther: (CE<C, E>) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading(it.value) },
@@ -11,8 +11,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldLoading(
 }
 
 inline fun <C, E, T> UCE<C, E>.foldLoading(
-    crossinline onLoading: () -> T,
-    crossinline onOther: (CE<C, E>) -> T
+    onLoading: () -> T,
+    onOther: (CE<C, E>) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading() },
@@ -21,8 +21,8 @@ inline fun <C, E, T> UCE<C, E>.foldLoading(
 }
 
 inline fun <C, T> UCT<C>.foldLoading(
-    crossinline onLoading: () -> T,
-    crossinline onOther: (CT<C>) -> T
+    onLoading: () -> T,
+    onOther: (CT<C>) -> T
 ): T {
     return foldTypes(
         onLoading = { onLoading() },

--- a/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
@@ -1,9 +1,9 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
-    crossinline onLoading: (Type.Loading<L>) -> T,
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onError: (Type.Error<E>) -> T
+    onLoading: (Type.Loading<L>) -> T,
+    onContent: (Type.Content<C>) -> T,
+    onError: (Type.Error<E>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading -> onLoading(type)
@@ -14,8 +14,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
 
 @JvmName("foldLoadingType")
 inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
-    crossinline onLoading: (Type.Loading<L>) -> T,
-    crossinline onOther: (CE<C, E>) -> T
+    onLoading: (Type.Loading<L>) -> T,
+    onOther: (CE<C, E>) -> T
 ): T {
     return foldTypes(
         onLoading = onLoading,
@@ -26,8 +26,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
 
 @JvmName("foldContentType")
 inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onOther: (LE<L, E>) -> T
+    onContent: (Type.Content<C>) -> T,
+    onOther: (LE<L, E>) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -38,8 +38,8 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
 
 @JvmName("foldErrorType")
 inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
-    crossinline onError: (Type.Error<E>) -> T,
-    crossinline onOther: (LC<L, C>) -> T
+    onError: (Type.Error<E>) -> T,
+    onOther: (LC<L, C>) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -49,9 +49,9 @@ inline fun <L, C, E, T> LCE<L, C, E>.foldTypes(
 }
 
 inline fun <C, E, T> UCE<C, E>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onError: (Type.Error<E>) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onContent: (Type.Content<C>) -> T,
+    onError: (Type.Error<E>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading.UnitType -> onLoading(type)
@@ -63,8 +63,8 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
 
 @JvmName("foldLoadingType")
 inline fun <C, E, T> UCE<C, E>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onOther: (CE<C, E>) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onOther: (CE<C, E>) -> T
 ): T {
     return foldTypes(
         onLoading = onLoading,
@@ -75,8 +75,8 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
 
 @JvmName("foldContentType")
 inline fun <C, E, T> UCE<C, E>.foldTypes(
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onOther: (UE<E>) -> T
+    onContent: (Type.Content<C>) -> T,
+    onOther: (UE<E>) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -87,8 +87,8 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
 
 @JvmName("foldErrorType")
 inline fun <C, E, T> UCE<C, E>.foldTypes(
-    crossinline onError: (Type.Error<E>) -> T,
-    crossinline onOther: (UC<C>) -> T
+    onError: (Type.Error<E>) -> T,
+    onOther: (UC<C>) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -98,9 +98,9 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
 }
 
 inline fun <C, T> UCT<C>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onError: (Type.Error.ThrowableType) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onContent: (Type.Content<C>) -> T,
+    onError: (Type.Error.ThrowableType) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading.UnitType -> onLoading(type)
@@ -112,8 +112,8 @@ inline fun <C, T> UCT<C>.foldTypes(
 
 @JvmName("foldLoadingType")
 inline fun <C, T> UCT<C>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onOther: (CT<C>) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onOther: (CT<C>) -> T
 ): T {
     return foldTypes(
         onLoading = onLoading,
@@ -124,8 +124,8 @@ inline fun <C, T> UCT<C>.foldTypes(
 
 @JvmName("foldContentType")
 inline fun <C, T> UCT<C>.foldTypes(
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onOther: (UT) -> T
+    onContent: (Type.Content<C>) -> T,
+    onOther: (UT) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -136,8 +136,8 @@ inline fun <C, T> UCT<C>.foldTypes(
 
 @JvmName("foldErrorType")
 inline fun <C, T> UCT<C>.foldTypes(
-    crossinline onError: (Type.Error.ThrowableType) -> T,
-    crossinline onOther: (UC<C>) -> T
+    onError: (Type.Error.ThrowableType) -> T,
+    onOther: (UC<C>) -> T
 ): T {
     return foldTypes(
         onLoading = onOther,
@@ -147,8 +147,8 @@ inline fun <C, T> UCT<C>.foldTypes(
 }
 
 inline fun <C, E, T> CE<C, E>.foldTypes(
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onError: (Type.Error<E>) -> T
+    onContent: (Type.Content<C>) -> T,
+    onError: (Type.Error<E>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Content -> onContent(type)
@@ -158,8 +158,8 @@ inline fun <C, E, T> CE<C, E>.foldTypes(
 }
 
 inline fun <C, T> CT<C>.foldTypes(
-    crossinline onContent: (Type.Content<C>) -> T,
-    crossinline onError: (Type.Error.ThrowableType) -> T
+    onContent: (Type.Content<C>) -> T,
+    onError: (Type.Error.ThrowableType) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Content -> onContent(type)
@@ -169,8 +169,8 @@ inline fun <C, T> CT<C>.foldTypes(
 }
 
 inline fun <L, C, T> LC<L, C>.foldTypes(
-    crossinline onLoading: (Type.Loading<L>) -> T,
-    crossinline onContent: (Type.Content<C>) -> T
+    onLoading: (Type.Loading<L>) -> T,
+    onContent: (Type.Content<C>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading -> onLoading(type)
@@ -180,8 +180,8 @@ inline fun <L, C, T> LC<L, C>.foldTypes(
 }
 
 inline fun <C, T> UC<C>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onContent: (Type.Content<C>) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onContent: (Type.Content<C>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading.UnitType -> onLoading(type)
@@ -191,8 +191,8 @@ inline fun <C, T> UC<C>.foldTypes(
 }
 
 inline fun <L, E, T> LE<L, E>.foldTypes(
-    crossinline onLoading: (Type.Loading<L>) -> T,
-    crossinline onError: (Type.Error<E>) -> T
+    onLoading: (Type.Loading<L>) -> T,
+    onError: (Type.Error<E>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading -> onLoading(type)
@@ -202,8 +202,8 @@ inline fun <L, E, T> LE<L, E>.foldTypes(
 }
 
 inline fun <L, T> LT<L>.foldTypes(
-    crossinline onLoading: (Type.Loading<L>) -> T,
-    crossinline onError: (Type.Error.ThrowableType) -> T
+    onLoading: (Type.Loading<L>) -> T,
+    onError: (Type.Error.ThrowableType) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading -> onLoading(type)
@@ -213,8 +213,8 @@ inline fun <L, T> LT<L>.foldTypes(
 }
 
 inline fun <E, T> UE<E>.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onError: (Type.Error<E>) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onError: (Type.Error<E>) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading.UnitType -> onLoading(type)
@@ -224,8 +224,8 @@ inline fun <E, T> UE<E>.foldTypes(
 }
 
 inline fun <T> UT.foldTypes(
-    crossinline onLoading: (Type.Loading.UnitType) -> T,
-    crossinline onError: (Type.Error.ThrowableType) -> T
+    onLoading: (Type.Loading.UnitType) -> T,
+    onError: (Type.Error.ThrowableType) -> T
 ): T {
     return when (val type = asLceType()) {
         is Type.Loading.UnitType -> onLoading(type)

--- a/lce/src/main/java/com/laimiux/lce/LC.kt
+++ b/lce/src/main/java/com/laimiux/lce/LC.kt
@@ -24,7 +24,7 @@ interface LC<out L, out C> {
          */
         inline fun <L, C : Any> fromNullable(
             content: C?,
-            crossinline onNull: () -> LC<L, C>
+            onNull: () -> LC<L, C>
         ): LC<L, C> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/LCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/LCE.kt
@@ -26,7 +26,7 @@ interface LCE<out L, out C, out E> {
          */
         inline fun <L, C : Any, E> fromNullable(
             content: C?,
-            crossinline onNull: () -> LCE<L, C, E>
+            onNull: () -> LCE<L, C, E>
         ): LCE<L, C, E> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/MapContent.kt
+++ b/lce/src/main/java/com/laimiux/lce/MapContent.kt
@@ -12,7 +12,7 @@ package com.laimiux.lce
  * ```
  */
 inline fun <L, C, E, NewC> LCE<L, C, E>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): LCE<L, NewC, E> {
     return foldTypes(
         onLoading = { it },
@@ -22,7 +22,7 @@ inline fun <L, C, E, NewC> LCE<L, C, E>.mapContent(
 }
 
 inline fun <C, E, NewC> UCE<C, E>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): UCE<NewC, E> {
     return foldTypes(
         onLoading = { it },
@@ -32,7 +32,7 @@ inline fun <C, E, NewC> UCE<C, E>.mapContent(
 }
 
 inline fun <C, NewC> UCT<C>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): UCT<NewC> {
     return foldTypes(
         onLoading = { it },
@@ -42,7 +42,7 @@ inline fun <C, NewC> UCT<C>.mapContent(
 }
 
 inline fun <C, E, NewC> CE<C, E>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): CE<NewC, E> {
     return foldTypes(
         onContent = { CE.content(map(it.value)) },
@@ -51,7 +51,7 @@ inline fun <C, E, NewC> CE<C, E>.mapContent(
 }
 
 inline fun <C, NewC> CT<C>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): CT<NewC> {
     return foldTypes(
         onContent = { CT.content(map(it.value)) },
@@ -60,7 +60,7 @@ inline fun <C, NewC> CT<C>.mapContent(
 }
 
 inline fun <L, C, NewC> LC<L, C>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): LC<L, NewC> {
     return foldTypes(
         onLoading = { it },
@@ -69,7 +69,7 @@ inline fun <L, C, NewC> LC<L, C>.mapContent(
 }
 
 inline fun <C, NewC> UC<C>.mapContent(
-    crossinline map: (C) -> NewC
+    map: (C) -> NewC
 ): UC<NewC> {
     return foldTypes(
         onLoading = { it },

--- a/lce/src/main/java/com/laimiux/lce/MapError.kt
+++ b/lce/src/main/java/com/laimiux/lce/MapError.kt
@@ -1,7 +1,7 @@
 package com.laimiux.lce
 
 inline fun <L, C, E, NewE> LCE<L, C, E>.mapError(
-    crossinline map: (E) -> NewE
+    map: (E) -> NewE
 ): LCE<L, C, NewE> {
     return foldTypes(
         onLoading = { it },
@@ -11,7 +11,7 @@ inline fun <L, C, E, NewE> LCE<L, C, E>.mapError(
 }
 
 inline fun <C, E, NewE> UCE<C, E>.mapError(
-    crossinline map: (E) -> NewE
+    map: (E) -> NewE
 ): UCE<C, NewE> {
     return foldTypes(
         onLoading = { it },
@@ -21,7 +21,7 @@ inline fun <C, E, NewE> UCE<C, E>.mapError(
 }
 
 inline fun <C> UCT<C>.mapError(
-    crossinline map: (Throwable) -> Throwable
+    map: (Throwable) -> Throwable
 ): UCT<C> {
     return foldTypes(
         onLoading = { it },
@@ -31,7 +31,7 @@ inline fun <C> UCT<C>.mapError(
 }
 
 inline fun <C, E, NewE> CE<C, E>.mapError(
-    crossinline map: (E) -> NewE
+    map: (E) -> NewE
 ): CE<C, NewE> {
     return foldTypes(
         onError = { CE.error(map(it.value)) },
@@ -40,7 +40,7 @@ inline fun <C, E, NewE> CE<C, E>.mapError(
 }
 
 inline fun <C> CT<C>.mapError(
-    crossinline map: (Throwable) -> Throwable
+    map: (Throwable) -> Throwable
 ): CT<C> {
     return foldTypes(
         onError = { CT.error(map(it.value)) },

--- a/lce/src/main/java/com/laimiux/lce/Merge.kt
+++ b/lce/src/main/java/com/laimiux/lce/Merge.kt
@@ -5,7 +5,7 @@ package com.laimiux.lce
  */
 inline fun <C, C2, E, T> UCE<C, E>.merge(
     other: UCE<C2, E>,
-    crossinline merge: (C, C2) -> T
+    merge: (C, C2) -> T
 ): UCE<T, E> {
     return takeFirstError(other) { first, second ->
         first.merge(second, merge).asUCE()
@@ -18,7 +18,7 @@ inline fun <C, C2, E, T> UCE<C, E>.merge(
 inline fun <C, C2, C3, E, T> UCE<C, E>.merge(
     second: UCE<C2, E>,
     third: UCE<C3, E>,
-    crossinline merge: (C, C2, C3) -> T
+    merge: (C, C2, C3) -> T
 ): UCE<T, E> {
     return takeFirstError(second, third) { firstUC, secondUC, thirdUC ->
         firstUC.merge(secondUC, thirdUC, merge).asUCE()
@@ -32,7 +32,7 @@ inline fun <C, C2, C3, C4, E, T> UCE<C, E>.merge(
     second: UCE<C2, E>,
     third: UCE<C3, E>,
     fourth: UCE<C4, E>,
-    crossinline merge: (C, C2, C3, C4) -> T
+    merge: (C, C2, C3, C4) -> T
 ): UCE<T, E> {
     return takeFirstError(second, third, fourth) { firstUC, secondUC, thirdUC, fourthUC ->
         firstUC.merge(secondUC, thirdUC, fourthUC, merge).asUCE()
@@ -53,7 +53,7 @@ fun <C, C2, E> UCE<C, E>.merge(other: UCE<C2, E>): UCE<Pair<C, C2>, E> {
  */
 inline fun <C, C2, T> UCT<C>.merge(
     second: UCT<C2>,
-    crossinline merge: (C, C2) -> T
+    merge: (C, C2) -> T
 ): UCT<T> {
     return takeFirstError(second) { firstUC, secondUC ->
         firstUC.merge(secondUC, merge).asUCT()
@@ -66,7 +66,7 @@ inline fun <C, C2, T> UCT<C>.merge(
 inline fun <C, C2, C3, T> UCT<C>.merge(
     second: UCT<C2>,
     third: UCT<C3>,
-    crossinline merge: (C, C2, C3) -> T
+    merge: (C, C2, C3) -> T
 ): UCT<T> {
     return takeFirstError(second, third) { firstUC, secondUC, thirdUC ->
         firstUC.merge(secondUC, thirdUC, merge).asUCT()
@@ -80,7 +80,7 @@ inline fun <C, C2, C3, C4, T> UCT<C>.merge(
     second: UCT<C2>,
     third: UCT<C3>,
     fourth: UCT<C4>,
-    crossinline merge: (C, C2, C3, C4) -> T
+    merge: (C, C2, C3, C4) -> T
 ): UCT<T> {
     return takeFirstError(second, third, fourth) { firstUC, secondUC, thirdUC, fourthUC ->
         firstUC.merge(secondUC, thirdUC, fourthUC, merge).asUCT()
@@ -108,7 +108,7 @@ fun <L, C, C2> LC<L, C>.merge(other: LC<L, C2>): LC<L, Pair<C, C2>> {
  */
 inline fun <L, C, C2, T> LC<L, C>.merge(
     other: LC<L, C2>,
-    crossinline merge: (C, C2) -> T
+    merge: (C, C2) -> T
 ): LC<L, T> {
     return flatMapContent { first ->
         other.flatMapContent { second ->
@@ -123,7 +123,7 @@ inline fun <L, C, C2, T> LC<L, C>.merge(
 inline fun <L, C, C2, C3, T> LC<L, C>.merge(
     second: LC<L, C2>,
     third: LC<L, C3>,
-    crossinline merge: (C, C2, C3) -> T
+    merge: (C, C2, C3) -> T
 ): LC<L, T> {
     return flatMapContent { firstContent ->
         second.flatMapContent { secondContent ->
@@ -141,7 +141,7 @@ inline fun <L, C, C2, C3, C4, T> LC<L, C>.merge(
     second: LC<L, C2>,
     third: LC<L, C3>,
     fourth: LC<L, C4>,
-    crossinline merge: (C, C2, C3, C4) -> T
+    merge: (C, C2, C3, C4) -> T
 ): LC<L, T> {
     return flatMapContent { firstContent ->
         second.flatMapContent { secondContent ->
@@ -167,7 +167,7 @@ fun <C, C2> UC<C>.merge(other: UC<C2>): UC<Pair<C, C2>> {
  */
 inline fun <C, C2, T> UC<C>.merge(
     other: UC<C2>,
-    crossinline merge: (C, C2) -> T
+    merge: (C, C2) -> T
 ): UC<T> {
     return flatMapContent { first ->
         other.flatMapContent { second ->
@@ -182,7 +182,7 @@ inline fun <C, C2, T> UC<C>.merge(
 inline fun <C, C2, C3, T> UC<C>.merge(
     second: UC<C2>,
     third: UC<C3>,
-    crossinline merge: (C, C2, C3) -> T
+    merge: (C, C2, C3) -> T
 ): UC<T> {
     return flatMapContent { firstContent ->
         second.flatMapContent { secondContent ->
@@ -200,7 +200,7 @@ inline fun <C, C2, C3, C4, T> UC<C>.merge(
     second: UC<C2>,
     third: UC<C3>,
     fourth: UC<C4>,
-    crossinline merge: (C, C2, C3, C4) -> T
+    merge: (C, C2, C3, C4) -> T
 ): UC<T> {
     return flatMapContent { firstContent ->
         second.flatMapContent { secondContent ->

--- a/lce/src/main/java/com/laimiux/lce/TakeErrorOrElse.kt
+++ b/lce/src/main/java/com/laimiux/lce/TakeErrorOrElse.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * Returns an error [UCE] or calls [onOther] with a loading or content [UC] type.
  */
 inline fun <C, E, T> UCE<C, E>.takeErrorOrElse(
-    crossinline onOther: (UC<C>) -> UCE<T, E>
+    onOther: (UC<C>) -> UCE<T, E>
 ): UCE<T, E> {
     return foldTypes(
         onError = { it },
@@ -17,7 +17,7 @@ inline fun <C, E, T> UCE<C, E>.takeErrorOrElse(
  * Returns an error [UCT] or calls [onOther] with a loading or content [UC] type.
  */
 inline fun <C, T> UCT<C>.takeErrorOrElse(
-    crossinline onOther: (UC<C>) -> UCT<T>
+    onOther: (UC<C>) -> UCT<T>
 ): UCT<T> {
     return foldTypes(
         onError = { it },

--- a/lce/src/main/java/com/laimiux/lce/TakeFirstError.kt
+++ b/lce/src/main/java/com/laimiux/lce/TakeFirstError.kt
@@ -5,7 +5,7 @@ package com.laimiux.lce
  */
 inline fun <C, C2, E, T> UCE<C, E>.takeFirstError(
     second: UCE<C2, E>,
-    crossinline onOther: (UC<C>, UC<C2>) -> UCE<T, E>
+    onOther: (UC<C>, UC<C2>) -> UCE<T, E>
 ): UCE<T, E> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { otherUc ->
@@ -20,7 +20,7 @@ inline fun <C, C2, E, T> UCE<C, E>.takeFirstError(
 inline fun <C, C2, C3, E, T> UCE<C, E>.takeFirstError(
     second: UCE<C2, E>,
     third: UCE<C3, E>,
-    crossinline onOther: (UC<C>, UC<C2>, UC<C3>) -> UCE<T, E>
+    onOther: (UC<C>, UC<C2>, UC<C3>) -> UCE<T, E>
 ): UCE<T, E> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { secondUC ->
@@ -38,7 +38,7 @@ inline fun <C, C2, C3, C4, E, T> UCE<C, E>.takeFirstError(
     second: UCE<C2, E>,
     third: UCE<C3, E>,
     fourth: UCE<C4, E>,
-    crossinline onOther: (UC<C>, UC<C2>, UC<C3>, UC<C4>) -> UCE<T, E>
+    onOther: (UC<C>, UC<C2>, UC<C3>, UC<C4>) -> UCE<T, E>
 ): UCE<T, E> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { secondUC ->
@@ -56,7 +56,7 @@ inline fun <C, C2, C3, C4, E, T> UCE<C, E>.takeFirstError(
  */
 inline fun <C, C2, T> UCT<C>.takeFirstError(
     second: UCT<C2>,
-    crossinline onOther: (UC<C>, UC<C2>) -> UCT<T>
+    onOther: (UC<C>, UC<C2>) -> UCT<T>
 ): UCT<T> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { otherUc ->
@@ -71,7 +71,7 @@ inline fun <C, C2, T> UCT<C>.takeFirstError(
 inline fun <C, C2, C3, T> UCT<C>.takeFirstError(
     second: UCT<C2>,
     third: UCT<C3>,
-    crossinline onOther: (UC<C>, UC<C2>, UC<C3>) -> UCT<T>
+    onOther: (UC<C>, UC<C2>, UC<C3>) -> UCT<T>
 ): UCT<T> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { secondUC ->
@@ -89,7 +89,7 @@ inline fun <C, C2, C3, C4, T> UCT<C>.takeFirstError(
         second: UCT<C2>,
         third: UCT<C3>,
         fourth: UCT<C4>,
-        crossinline onOther: (UC<C>, UC<C2>, UC<C3>, UC<C4>) -> UCT<T>
+        onOther: (UC<C>, UC<C2>, UC<C3>, UC<C4>) -> UCT<T>
 ): UCT<T> {
     return takeErrorOrElse { uc ->
         second.takeErrorOrElse { secondUC ->

--- a/lce/src/main/java/com/laimiux/lce/UC.kt
+++ b/lce/src/main/java/com/laimiux/lce/UC.kt
@@ -21,7 +21,7 @@ interface UC<out C> {
          */
         inline fun <C : Any> fromNullable(
             content: C?,
-            crossinline onNull: () -> UC<C>
+            onNull: () -> UC<C>
         ): UC<C> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/UCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/UCE.kt
@@ -22,7 +22,7 @@ interface UCE<out C, out E> {
          */
         inline fun <C : Any, E> fromNullable(
             content: C?,
-            crossinline onNull: () -> UCE<C, E>
+            onNull: () -> UCE<C, E>
         ): UCE<C, E> {
             return if (content == null) {
                 onNull()

--- a/lce/src/main/java/com/laimiux/lce/UCT.kt
+++ b/lce/src/main/java/com/laimiux/lce/UCT.kt
@@ -24,7 +24,7 @@ interface UCT<out C> {
          */
         inline fun <C : Any> fromNullable(
             content: C?,
-            crossinline onNull: () -> UCT<C>
+            onNull: () -> UCT<C>
         ): UCT<C> {
             return if (content == null) {
                 onNull()


### PR DESCRIPTION
`crossinline` declarations [are used when a callback passed to an `inline` method might escape the current execution context](https://kotlinlang.org/docs/inline-functions.html#non-local-returns), which makes it impossible to use non-local returns. This is not the case for most methods here though, so the declaration can be removed and non-local returns can be used. This can simplify handling some cases:

```
val content = uct.fold(
  onLoading = { return },
  onError = { return },
  onContent = { it }
)
doSomething(content)
```