### PR TITLE
Mark interfaces as sealed

### DIFF
--- a/lce/src/main/java/com/laimiux/lce/CE.kt
+++ b/lce/src/main/java/com/laimiux/lce/CE.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * CE stands for Content / Error. A type that represents either content state of type [C] or
  * error state of type [E].
  */
-interface CE<out C, out E> {
+sealed interface CE<out C, out E> {
     companion object {
         fun <T> content(content: T): CE<T, Nothing> = Type.Content(content)
 

--- a/lce/src/main/java/com/laimiux/lce/CT.kt
+++ b/lce/src/main/java/com/laimiux/lce/CT.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * CT stands for Content / Throwable. A type that represents content state of type [C] or
  * error state of [Throwable] type.
  */
-interface CT<out C> {
+sealed interface CT<out C> {
     companion object {
         fun <T> content(content: T): CT<T> = Type.Content(content)
         fun error(error: Throwable): CT<Nothing> = Type.Error(error)

--- a/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
+++ b/lce/src/main/java/com/laimiux/lce/FoldTypes.kt
@@ -53,11 +53,10 @@ inline fun <C, E, T> UCE<C, E>.foldTypes(
     crossinline onContent: (Type.Content<C>) -> T,
     crossinline onError: (Type.Error<E>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading.UnitType -> onLoading(type)
-        is Type.Content -> onContent(type)
-        is Type.Error -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading.UnitType -> onLoading(this)
+        is Type.Content -> onContent(this)
+        is Type.Error -> onError(this)
     }
 }
 
@@ -102,11 +101,10 @@ inline fun <C, T> UCT<C>.foldTypes(
     crossinline onContent: (Type.Content<C>) -> T,
     crossinline onError: (Type.Error.ThrowableType) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading.UnitType -> onLoading(type)
-        is Type.Content -> onContent(type)
-        is Type.Error.ThrowableType -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading.UnitType -> onLoading(this)
+        is Type.Content -> onContent(this)
+        is Type.Error.ThrowableType -> onError(this)
     }
 }
 
@@ -150,10 +148,9 @@ inline fun <C, E, T> CE<C, E>.foldTypes(
     crossinline onContent: (Type.Content<C>) -> T,
     crossinline onError: (Type.Error<E>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Content -> onContent(type)
-        is Type.Error -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Content -> onContent(this)
+        is Type.Error -> onError(this)
     }
 }
 
@@ -161,10 +158,9 @@ inline fun <C, T> CT<C>.foldTypes(
     crossinline onContent: (Type.Content<C>) -> T,
     crossinline onError: (Type.Error.ThrowableType) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Content -> onContent(type)
-        is Type.Error.ThrowableType -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Content -> onContent(this)
+        is Type.Error.ThrowableType -> onError(this)
     }
 }
 
@@ -172,10 +168,9 @@ inline fun <L, C, T> LC<L, C>.foldTypes(
     crossinline onLoading: (Type.Loading<L>) -> T,
     crossinline onContent: (Type.Content<C>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading -> onLoading(type)
-        is Type.Content -> onContent(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading -> onLoading(this)
+        is Type.Content -> onContent(this)
     }
 }
 
@@ -183,10 +178,9 @@ inline fun <C, T> UC<C>.foldTypes(
     crossinline onLoading: (Type.Loading.UnitType) -> T,
     crossinline onContent: (Type.Content<C>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading.UnitType -> onLoading(type)
-        is Type.Content -> onContent(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading.UnitType -> onLoading(this)
+        is Type.Content -> onContent(this)
     }
 }
 
@@ -194,10 +188,9 @@ inline fun <L, E, T> LE<L, E>.foldTypes(
     crossinline onLoading: (Type.Loading<L>) -> T,
     crossinline onError: (Type.Error<E>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading -> onLoading(type)
-        is Type.Error -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading -> onLoading(this)
+        is Type.Error -> onError(this)
     }
 }
 
@@ -205,10 +198,9 @@ inline fun <L, T> LT<L>.foldTypes(
     crossinline onLoading: (Type.Loading<L>) -> T,
     crossinline onError: (Type.Error.ThrowableType) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading -> onLoading(type)
-        is Type.Error.ThrowableType -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading -> onLoading(this)
+        is Type.Error.ThrowableType -> onError(this)
     }
 }
 
@@ -216,10 +208,9 @@ inline fun <E, T> UE<E>.foldTypes(
     crossinline onLoading: (Type.Loading.UnitType) -> T,
     crossinline onError: (Type.Error<E>) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading.UnitType -> onLoading(type)
-        is Type.Error -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading.UnitType -> onLoading(this)
+        is Type.Error -> onError(this)
     }
 }
 
@@ -227,9 +218,8 @@ inline fun <T> UT.foldTypes(
     crossinline onLoading: (Type.Loading.UnitType) -> T,
     crossinline onError: (Type.Error.ThrowableType) -> T
 ): T {
-    return when (val type = asLceType()) {
-        is Type.Loading.UnitType -> onLoading(type)
-        is Type.Error.ThrowableType -> onError(type)
-        else -> throw IllegalStateException("this should not happen: $type")
+    return when (this) {
+        is Type.Loading.UnitType -> onLoading(this)
+        is Type.Error.ThrowableType -> onError(this)
     }
 }

--- a/lce/src/main/java/com/laimiux/lce/LC.kt
+++ b/lce/src/main/java/com/laimiux/lce/LC.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * LC stands for Loading / Content. A type that represents either
  * loading of type [L] or content of type [C].
  */
-interface LC<out L, out C> {
+sealed interface LC<out L, out C> {
     companion object {
         fun loading(): LC<Unit, Nothing> = Type.Loading()
         fun loading(unit: Unit): LC<Unit, Nothing> = Type.Loading(unit)

--- a/lce/src/main/java/com/laimiux/lce/LCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/LCE.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * Lce stands for Loading / Content / Error. A type that represents either
  * loading of type [L], content of type [C] or error of type [E].
  */
-interface LCE<out L, out C, out E> {
+sealed interface LCE<out L, out C, out E> {
     companion object {
         fun loading(): LCE<Unit, Nothing, Nothing> = Type.Loading()
         fun loading(unit: Unit): LCE<Unit, Nothing, Nothing> = Type.Loading(unit)

--- a/lce/src/main/java/com/laimiux/lce/LE.kt
+++ b/lce/src/main/java/com/laimiux/lce/LE.kt
@@ -6,7 +6,7 @@ package com.laimiux.lce
  *
  * Note: It's an intermediary type to enable certain APIs and should rarely be used.
  */
-interface LE<out L, out E> {
+sealed interface LE<out L, out E> {
 
     fun isLoading(): Boolean
     fun isError(): Boolean

--- a/lce/src/main/java/com/laimiux/lce/LT.kt
+++ b/lce/src/main/java/com/laimiux/lce/LT.kt
@@ -6,7 +6,7 @@ package com.laimiux.lce
  *
  * Note: It's an intermediary type to enable certain APIs and should rarely be used.
  */
-interface LT<out L> {
+sealed interface LT<out L> {
 
     fun isLoading(): Boolean
     fun isError(): Boolean

--- a/lce/src/main/java/com/laimiux/lce/UC.kt
+++ b/lce/src/main/java/com/laimiux/lce/UC.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * UC stands for Unit / Content. A type that represents either loading state of type [Unit]
  * or content state of type [C].
  */
-interface UC<out C> {
+sealed interface UC<out C> {
     companion object {
         fun loading(): UC<Nothing> = Type.Loading()
         fun <C> content(value: C): UC<C> = Type.Content(value)

--- a/lce/src/main/java/com/laimiux/lce/UCE.kt
+++ b/lce/src/main/java/com/laimiux/lce/UCE.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * UCE stands for Unit / Content / Error. A type that represents either loading state of type [Unit],
  * content state of type [C] or error state of type [E].
  */
-interface UCE<out C, out E> {
+sealed interface UCE<out C, out E> {
     companion object {
         fun loading(): UCE<Nothing, Nothing> = Type.Loading()
         fun <T> content(value: T): UCE<T, Nothing> = Type.Content(value)

--- a/lce/src/main/java/com/laimiux/lce/UCT.kt
+++ b/lce/src/main/java/com/laimiux/lce/UCT.kt
@@ -4,7 +4,7 @@ package com.laimiux.lce
  * UCT stands for Unit / Content / Throwable. A type that represents either loading state of
  * type Unit, content state of type [C] or error state of [Throwable] type.
  */
-interface UCT<out C> {
+sealed interface UCT<out C> {
     companion object {
         fun loading(): UCT<Nothing> = Type.Loading()
 

--- a/lce/src/main/java/com/laimiux/lce/UE.kt
+++ b/lce/src/main/java/com/laimiux/lce/UE.kt
@@ -6,7 +6,7 @@ package com.laimiux.lce
  *
  * Note: It's an intermediary type to enable certain APIs and should rarely be used.
  */
-interface UE<out E> {
+sealed interface UE<out E> {
 
     fun isLoading(): Boolean
     fun isError(): Boolean

--- a/lce/src/main/java/com/laimiux/lce/UT.kt
+++ b/lce/src/main/java/com/laimiux/lce/UT.kt
@@ -6,7 +6,7 @@ package com.laimiux.lce
  *
  * Note: It's an intermediary type to enable certain APIs and should rarely be used.
  */
-interface UT {
+sealed interface UT {
 
     fun isLoading(): Boolean
     fun isError(): Boolean


### PR DESCRIPTION
This allows simplifying `when` expressions by removing the need for an `else` condition.