### PR TITLE
Update GitHub Actions to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle--${{ hashFiles('gradle/libs.versions.toml') }}-${{ hashFiles('**/build.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}


### PR DESCRIPTION
Fixes deprecation warning: "This request has been automatically failed because it uses a deprecated version of actions/cache: v2"

- Update actions/checkout from v2 to v4
- Update actions/cache from v2 to v4